### PR TITLE
Rebuild for pytorch113

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+pytorch:
+- '1.13'
 target_platform:
 - osx-64
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: aeea3bd08f47fcfe3b301f1190928dec482938956a1ab8ba568851deed94bda5
 
 build:
-  number: 5
+  number: 6
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [win]
   rpaths:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,11 @@
-{% set name = "norse" %}
 {% set version = "0.0.7.post1" %}
 
-
 package:
-  name: {{ name|lower }}
+  name: norse
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/norse-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/n/norse/norse-{{ version }}.tar.gz
   sha256: aeea3bd08f47fcfe3b301f1190928dec482938956a1ab8ba568851deed94bda5
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,11 @@ requirements:
   host:
     - pip
     - python
-    - pytorch >=1.9
+    - pytorch
   run:
     - python
     - numpy
     - torchvision >=0.10.0
-    - {{ pin_compatible('pytorch', max_pin='x.x.x') }}
 
 test:
   imports:


### PR DESCRIPTION
#6 did not do this correctly; things only worked because this feedstock isn't using the pytorch pinning (correctly).